### PR TITLE
Add Firmware Versioning explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ The firmwares are obtained compiling the source code in [icub-firmware](https://
 
 For more information on how to upload this firmwares to the boards in the iCub robot, please see the [iCub wiki page on Firmware](http://wiki.icub.org/wiki/Firmware).
 
+## Firmware Versioning Table 
+
+This table contains information of which version of each release of icub-firmware-build (and corresponding [distro release](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) ) correspond to each firmware version. This is useful to quickly understand to which distro a robot is updated by looking at the firmware version in the FirmwareUpdater tool. 
+
+| [Distro](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) | `icub-firmware-build` | `ems`   | `mc4plus` | `mc2plus`  | `mtb4`   | `strain2` | `2foc`   | `rfe`    | `canprot` | 
+|:----------------------------------------------------------------------------:|:---------------------:|:-------:|:---------:|:----------:|:--------:|:---------:|:--------:|:--------:|:---------:| 
+| `v2020.11`                                                                   | `v1.18.0`             | `v3.33` | `v3.26`   | `v3.17`    | `v1.4.5` | `v2.0.9`  | `v2.3.3` | `v1.2.0` | `v2.0`    |
+| `v2020.08`                                                                   | `v1.17.0`             | `v3.33` | `v3.26`   | `v3.17`    | `v1.4.5` | `v2.0.9`  | `v2.3.3` | `v1.2.0` | `v2.0`    | 
+
+
 ## Maintainers
 This repository is maintained by:
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ For more information on how to upload this firmwares to the boards in the iCub r
 
 ## Firmware Versioning Table 
 
-This table contains information of which version of each release of icub-firmware-build (and corresponding [distro release](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) ) correspond to each firmware version. This is useful to quickly understand to which distro a robot is updated by looking at the firmware version in the FirmwareUpdater tool. 
+The information of which version of each release of icub-firmware-build (and corresponding [distro release](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) ) correspond to each firmware version is contained in the `info/firmware.info.xml` file. The following table provide contain links to this file in the different releases, to quickly access it. 
 
-| [Distro](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) | `icub-firmware-build` | `ems`   | `mc4plus` | `mc2plus`  | `mtb4`   | `strain2` | `2foc`   | `rfe`    | `canprot` | 
-|:----------------------------------------------------------------------------:|:---------------------:|:-------:|:---------:|:----------:|:--------:|:---------:|:--------:|:--------:|:---------:| 
-| `v2020.11`                                                                   | `v1.18.0`             | `v3.33` | `v3.26`   | `v3.17`    | `v1.4.5` | `v2.0.9`  | `v2.3.3` | `v1.2.0` | `v2.0`    |
-| `v2020.08`                                                                   | `v1.17.0`             | `v3.33` | `v3.26`   | `v3.17`    | `v1.4.5` | `v2.0.9`  | `v2.3.3` | `v1.2.0` | `v2.0`    | 
-
+| [Distro](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) | `icub-firmware-build` | `info/firmware.info.xml` |
+|:----------------------------------------------------------------------------:|:---------------------:|:-------:|
+| `v2020.11`                                                                   | `v1.18.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.18.0/info/firmware.info.xml) | 
+| `v2020.08`                                                                   | `v1.17.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.17.0/info/firmware.info.xml) | 
+| `v2020.05`                                                                   | `v1.16.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.16.0/info/firmware.info.xml) | 
+| `v2020.02`                                                                   | `v1.15.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.15.0/info/firmware.info.xml) | 
 
 ## Maintainers
 This repository is maintained by:


### PR DESCRIPTION
This is just a proposal. 

Last friday discussing about the status of the iCubGenova04 robot, I noticed that it was not trivial to go from the firmware versions that you can see with `FirmwareUpdater`, to the relative `icub-firmware-build`  tag and corresponding distro. For this reason, I think that a table such as the one in the PR can be useful for users and for people doing mantainance, to quickly know to which distro a given firmware version corresponds. This can be done in several way (we could move this info closer to https://github.com/icub-tech-iit/documentation, keep it in a `.json` file and generate the table as done in https://github.com/icub-tech-iit/documentation/pull/55, add more board), but I think that even just updating the README is probably already useful. A con is that know we need to remember to update it.

For the moment the content is populated by inspecting the commit messages, but let me know if I did something wrong. 

cc @marcoaccame @ale-git @davidetome @violadelbono @julijenv  @isorrentino @GiulioRomualdi @giovannipizzolante 

 