### PR TITLE
Update Firmware Versioning Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The information of which version of each release of icub-firmware-build (and cor
 
 | [Distro](https://icub-tech-iit.github.io/documentation/sw_versioning_table/) | `icub-firmware-build` | `info/firmware.info.xml` |
 |:----------------------------------------------------------------------------:|:---------------------:|:-------:|
+| `v2021.08`                                                                   | `v1.21.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.21.0/info/firmware.info.xml) | 
+| `v2021.05`                                                                   | `v1.20.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.20.0/info/firmware.info.xml) | 
+| `v2021.02`                                                                   | `v1.19.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.19.0/info/firmware.info.xml) | 
 | `v2020.11`                                                                   | `v1.18.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.18.0/info/firmware.info.xml) | 
 | `v2020.08`                                                                   | `v1.17.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.17.0/info/firmware.info.xml) | 
 | `v2020.05`                                                                   | `v1.16.0`             |  [`info/firmware.info.xml`](https://github.com/robotology/icub-firmware-build/blob/v1.16.0/info/firmware.info.xml) | 


### PR DESCRIPTION
It turns out it was outdated. See https://github.com/robotology/icub-firmware-build/pull/17 for the rationale for the table.

However, to avoid that in the future it becames outdated, we should remember to update it at each distro. @Nicogene 

fyi @sgiraz @GiulioRomualdi @isorrentino 