### PR TITLE
Fixed version of the foc board to be 3.3.22 as from PR #118

### DIFF
--- a/info/firmware.info.xml
+++ b/info/firmware.info.xml
@@ -110,7 +110,7 @@
     <board type="foc">
         <firmware>
             <file>../CAN/2foc/2foc.hex</file>
-            <version major='3' minor='4' build='0'/>
+            <version major='3' minor='3' build='22'/>
         </firmware>
     </board>
 


### PR DESCRIPTION

Fixed version of the `foc` board to be 3.3.22 in file `firmware.info.xml` as from PR #118