### PR TITLE
Add CMakeLists.txt to install firmware and scripts 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Fondazione Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.0...3.28)
+
+project(icub-firmware)
+
+include(GNUInstallDirs)
+
+set(ICUB_FIRMWARE_INSTALL_ROOT ${CMAKE_INSTALL_DATAROOTDIR}/icub-firmware)
+
+install(DIRECTORY CAN DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT})
+install(DIRECTORY ETH DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT})
+install(DIRECTORY info DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT})
+install(DIRECTORY scripts DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT})


### PR DESCRIPTION
This PR adds a minimal `CMakeLists.txt` to the repo, that installs firmware files and scripts to `<install_prefix>/share/icub-firmware`, using the same structure used in the icub-firmware-build repo itself. 

This is done to simplify installation of `icub-firmware-build`  as part of the robotology-superbuild. Installation of the firmware ensures that the superbuild can be used (including icub-firmware-build) even if only the `robotology-superbuild/build/install` (or anyhow `YCM_EP_INSTALL_DIR`   is present), while `robotology-superbuild/src` is not presented anymore. Deleting the `robotology-superbuild/src` folder is quite a common pattern for example in Docker images, to save space once the build is completed.

In a similar way, the `CMakeLists.txt` added here can be used to generate a conda package for icub-firmware-build repository.

