### PR TITLE
Fix bug in scripts for updating all the boards

### DIFF
--- a/scripts/FirmwareUpdater.script.update.all.ems4.sh
+++ b/scripts/FirmwareUpdater.script.update.all.ems4.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b ems4 -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.ems4.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b ems4 -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.ems4.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p all -b ems4 -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.ems4.txt
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b ems4 -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.ems4.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.all.mc4plus.sh
+++ b/scripts/FirmwareUpdater.script.update.all.mc4plus.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b mc4plus -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.mc4plus.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b mc4plus -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.mc4plus.txt
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p all -b mc4plus -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.mc4plus.txt
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -b mc4plus -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.mc4plus.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.all.sh
+++ b/scripts/FirmwareUpdater.script.update.all.sh
@@ -7,10 +7,13 @@
 echo ""
 echo ""
 echo ""
+echo "This script is about to install the standard FW binary on all the boards of $YARP_ROBOT_NAME"
+read -p "Continue? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p all -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.txt
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.all.txt"
 echo ""


### PR DESCRIPTION
Today, @GiulioRomualdi and I tested the scripts for updating all the boards of `ergoCubSN001`. The only script that successfully updated the boards was `FirmwareUpdater.script.update.all.foc.sh`. The other scripts, such as `FirmwareUpdater.script.update.all.sh`, failed. This PR fixes some of the scripts with the correct command.