### PR TITLE
Update st-link_BAT.bat file

### DIFF
--- a/CAN/bat/st-link/readme.txt
+++ b/CAN/bat/st-link/readme.txt
@@ -1,9 +1,9 @@
 
-in order to use this script you must have "STM32 ST-LINK Utility" installed. You also must have a "ST-LINK" programming device. 
+in order to use this script you must have "STM32CubeProgrammer" and the its CLI variant (installed by default) installed. You also must have a "ST-LINK/v3" programming device. 
 
 use this script to erase/burn loader/burn app
 
-    a. attach a st-link2 to the board.
+    a. attach a st-link/v3 to the board.
     b. power the board on
     c. launch the .bat 
     d. power the board off and then on. 

--- a/CAN/bat/st-link/st-link_BAT.bat
+++ b/CAN/bat/st-link/st-link_BAT.bat
@@ -1,43 +1,42 @@
 :start
 @echo off
 
-reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
-
-if %OS%==32BIT set PATH=%ProgramFiles%
-if %OS%==64BIT set PATH=%ProgramFiles(x86)%
+set PATH=%ProgramFiles%
 
 echo;
 echo Select the target:
-echo [1] iCub3
+echo [1] iCub-ergoCub
 echo [2] R1
 set choice=
 set /p choice=Type the number: 
 if not '%choice%'=='' set choice=%choice:~0,1%
-if '%choice%'=='1' goto :iCub3
+if '%choice%'=='1' goto :iCub-ergoCub
 if '%choice%'=='2' goto :R1
 echo "%choice%" is not valid, try again
 echo;
 goto :start
-:iCub3
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -ME
-echo;
-echo Programming BAT with target iCub3
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -c -P "..\bat.icub3.hex"
+:iCub-ergoCub
+echo Connecting BAT to the STLink-v3
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD freq=8000 ap=0 reset=SWrst
 echo;
 echo;
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -Rst -Run
+echo Programming BAT with target iCub-ergoCub
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD -d "..\bat.hex" 0x08000000 --verify
+echo;
+echo;
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD -Rst -Run
 echo;
 echo;
 if  %errorlevel% NEQ 0 goto :error
 goto :end
 :R1
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -ME
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD freq=8000 ap=0 reset=SWrst
 echo;
 echo Programming BAT with target R1
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -c -P "..\bat.r1.hex"
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD -d "..\bat.r1.hex" 0x08000000 --verify
 echo;
 echo;
-"%PATH%\STMicroelectronics\STM32 ST-LINK Utility\ST-LINK Utility\ST-LINK_CLI.exe" -Rst -Run
+"%PATH%\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=SWD -Rst -Run
 echo;
 echo;
 if %errorlevel% NEQ 0 goto :error

--- a/CAN/bat/st-link/st-link_BAT.bat
+++ b/CAN/bat/st-link/st-link_BAT.bat
@@ -43,7 +43,9 @@ if %errorlevel% NEQ 0 goto :error
 goto :end
 :error
 echo There was an error.
+PAUSE
 EXIT 1
 :end
 echo End.
+PAUSE
 EXIT 0


### PR DESCRIPTION
Now you can program BAT board using that script instead of doing it manually with STM32CubeProgrammer.
I've updated the bash script for windows so that it is now possible to program the BAT board just double clicking the script instead of doing it manually using the `STM32CubeProgrammer`.

In order to complete the updating, as mentioned in the procedure, it is mandatory to have installed the `STM32CubeProgrammer Sw` and its CLI (Command Line Interface). Moreover, it is needed that the BAT is connected by SWD connection (flat grey cable) to a STLink-v3 programmer

Related to the updated documentation for flashing and testing BAT and screen improved with this PR: https://github.com/icub-tech-iit/procedures/pull/95