### PR TITLE
Updete all fw-updater scripts

### DIFF
--- a/scripts/FirmwareUpdater.script.topology.all.sh
+++ b/scripts/FirmwareUpdater.script.topology.all.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a topology | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.topology.all.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a topology | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.topology.all.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p all -a topology | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.topology.all.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p all -a topology | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.topology.all.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.face.sh
+++ b/scripts/FirmwareUpdater.script.update.face.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p face -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.face.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p face -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.face.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p face -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.face.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p face -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.face.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.head.sh
+++ b/scripts/FirmwareUpdater.script.update.head.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p head -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.head.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p head -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.head.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p head -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.head.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p head -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.head.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.left_arm.sh
+++ b/scripts/FirmwareUpdater.script.update.left_arm.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_arm.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_arm.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p left_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_arm.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_arm.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.left_leg.sh
+++ b/scripts/FirmwareUpdater.script.update.left_leg.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_leg.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_leg.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p left_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_leg.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.left_leg.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.right_arm.sh
+++ b/scripts/FirmwareUpdater.script.update.right_arm.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_arm.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_arm.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p right_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_arm.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_arm -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_arm.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.right_leg.sh
+++ b/scripts/FirmwareUpdater.script.update.right_leg.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_leg.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_leg.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p right_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_leg.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p right_leg -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.right_leg.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.update.torso.sh
+++ b/scripts/FirmwareUpdater.script.update.torso.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p torso -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.torso.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p torso -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.torso.txt 
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p torso -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.torso.txt 
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p torso -a update | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.update.torso.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.verify.left_leg.ems4.sh
+++ b/scripts/FirmwareUpdater.script.verify.left_leg.ems4.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -b ems4 -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.ems4.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -b ems4 -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.ems4.txt
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p left_leg -b ems4 -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.ems4.txt
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -b ems4 -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.ems4.txt"
 echo ""

--- a/scripts/FirmwareUpdater.script.verify.left_leg.sh
+++ b/scripts/FirmwareUpdater.script.verify.left_leg.sh
@@ -10,7 +10,7 @@ echo ""
 
 echo "this bash is executing: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.txt"
 echo ""
-./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.txt
+./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml | grep ^\".*$ | sed 's/"//g'` -f ../info/firmware.info.xml -p left_leg -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.txt
 echo ""
 echo "this bash has executed: ./manageFWrobot.py -n `yarp resource --from network.$YARP_ROBOT_NAME.xml` -f ../info/firmware.info.xml -p left_leg -a verify | tee ../logs/log.of.FirmwareUpdater.$YARP_ROBOT_NAME.verify.left_leg.txt"
 echo ""


### PR DESCRIPTION
The aim of this PR fixes all the `fw-updater` scripts to parse the output on the yarp resource command correctly.

**Datails**
The scripts for single parts were not updated with this fix: we need to update each script that calls  `yarp resource --from network-file.xml` because its output changed almost 1 year ago and now it is not only the path of the file but several debug lines. Since the script updates automatically the fwUpdater searches the network file by the `yarp resource` module, they should be updated accordingly. It was already done for some of them in this pr https://github.com/robotology/icub-firmware-build/pull/149.
(See here for more details https://github.com/icub-tech-iit/sw-management/issues/162#issuecomment-1934383087)