### PR TITLE
Fix missing @ONLY argument in configure_file invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ foreach(bash_script ${bash_scripts})
                        ${CMAKE_INSTALL_PREFIX}/${ICUB_FIRMWARE_INSTALL_ROOT}/scripts)
     get_filename_component(ICUB_FIRMARE_BASH_SCRIPT_NAME ${bash_script} NAME)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/FirmwareUpdater.script.redirect.sh.in
-                   ${CMAKE_CURRENT_BINARY_DIR}/${ICUB_FIRMARE_BASH_SCRIPT_NAME})
+                   ${CMAKE_CURRENT_BINARY_DIR}/${ICUB_FIRMARE_BASH_SCRIPT_NAME}
+                   @ONLY)
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${ICUB_FIRMARE_BASH_SCRIPT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach()
 


### PR DESCRIPTION
Apparently I forgot to add a missing commit to the PR https://github.com/robotology/icub-firmware-build/pull/183 . Without this fix, the `icub-firmware-build` CMake configure (and hence the superbuild) fails with:

~~~
2024-12-04T12:00:49.5306983Z CMake Error at CMakeLists.txt:44 (configure_file):
2024-12-04T12:00:49.5307476Z   Syntax error in cmake code at
2024-12-04T12:00:49.5307711Z 
2024-12-04T12:00:49.5308287Z     /home/runner/work/robotology-superbuild/robotology-superbuild/src/icub-firmware-build/CMakeLists.txt:44
2024-12-04T12:00:49.5308990Z 
2024-12-04T12:00:49.5309117Z   when parsing string
2024-12-04T12:00:49.5309321Z 
2024-12-04T12:00:49.5309647Z     scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
2024-12-04T12:00:49.5310143Z 
2024-12-04T12:00:49.5310382Z   Invalid character ('[') in a variable name: 'BASH_SOURCE'
2024-12-04T12:00:49.5310763Z 
2024-12-04T12:00:49.5310769Z 
2024-12-04T12:00:49.5310933Z -- Configuring incomplete, errors occurred
~~~