### PR TITLE
Fix installation of manageFW.py script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB py_scripts ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.py)
 # Python scripts are directly installed in ${ICUB_FIRMWARE_INSTALL_ROOT}/scripts,
 # as they are not invoked directly by the user
 foreach(py_script ${py_scripts})
-    install(PROGRAMS ${script} DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT}/scripts)
+    install(PROGRAMS ${py_script} DESTINATION ${ICUB_FIRMWARE_INSTALL_ROOT}/scripts)
 endforeach()
 
 # Bash scripts are directly installed in ${ICUB_FIRMWARE_INSTALL_ROOT}/scripts,


### PR DESCRIPTION
Fix problem reported by @isorrentino in https://github.com/robotology/icub-firmware-build/issues/176#issuecomment-2595904122 . Due to a typo `manageFW.py` were never installed, and then all the FirmwareUpdate scripts were not working when invoked from the install folder.