### PR TITLE
add CI checking fw info changes

### DIFF
--- a/.github/workflows/pr-folder-check.yml
+++ b/.github/workflows/pr-folder-check.yml
@@ -1,0 +1,34 @@
+name: PR Folder Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-files:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get PR files
+      id: pr_files
+      run: |
+        PR_NUMBER=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+             -H "Accept: application/vnd.github.v3+json" \
+             https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/files > pr_files.json
+
+    - name: Check if specific files are modified
+      id: check_files
+      run: |
+        TMP_OR_DATA_MODIFIED=$(jq '.[] | select(.filename | startswith("ETH/AMC") or startswith("CAN/") or startswith("ETH/EMS/bin/application") or startswith("ETH/MC2PLUS/bin/application") or startswith("ETH/MC4PLUS/bin/application") )' pr_files.json)
+        SPECIFIC_FILE_MODIFIED=$(jq '.[] | select(.filename == "info/firmware.info.xml")' pr_files.json)
+
+        if [ -n "$TMP_OR_DATA_MODIFIED" ] && [ -z "$SPECIFIC_FILE_MODIFIED" ]; then
+          echo "The board's binary was updated, however, the info/firmware.info.xml file was not."
+          exit 1
+        else
+          echo "All required files were modified as expected."
+        fi


### PR DESCRIPTION
This PR introduces a check to ensure that whenever a binary is updated, the info/firmware.info.xml file is also updated in the same pull request. Note: This check only verifies the presence of an update to info/firmware.info.xml, not the accuracy of the version number within.

I already tested this action on my fork with some PRs